### PR TITLE
Moved update functionality to GetVotes function

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,8 +38,6 @@ type CurrentAction struct {
 
 func GetCurrentAction(w http.ResponseWriter, r *http.Request) {
 
-	update()
-
 	json.NewEncoder(w).Encode(lastExecutedAction)
 }
 
@@ -181,6 +179,8 @@ Example response from GET /votes
 }
 */
 func GetVotes(w http.ResponseWriter, r *http.Request) {
+
+	update()
 
 	currentVoteInfo := &CurrentVoteInfo{
 		Actions: []ActionInfo{


### PR DESCRIPTION
With this update, the vote count will reset as expected when GET /votes is called, after the voting time period has ended
